### PR TITLE
Update subscription & componentplan docs, add image override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea

--- a/docs/core/userguide/component.md
+++ b/docs/core/userguide/component.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 2
 ---
-
 # 组件
 
 组件是将 `chart package` 映射为集群资源的一个概念，组件定义了 `chart package` 的基础描述信息，版本信息等。组件一般由仓库创建出来，无需手动创建。
@@ -13,6 +12,7 @@ sidebar_position: 2
 下面是手动创建一个组件示例：
 
 1. 准备组件 component.yaml
+
 ```yaml
 apiVersion: core.kubebb.k8s.com.cn/v1alpha1
 kind: Component
@@ -84,56 +84,47 @@ kubectl -nkubebb-system patch component.core.kubebb.k8s.com.cn repository-bitnam
 
 ## CRD 定义说明
 
-CRD 的代码定义位于 [ComponentTypes](https://github.com/kubebb/core/blob/main/api/v1alpha1/component_types.go)。组件的信息都定在 `status` 中， 接下来会详细介绍每个字段的含义及其作用。 
+CRD 的代码定义位于 [ComponentTypes](https://github.com/kubebb/core/blob/main/api/v1alpha1/component_types.go)。组件的信息都定在 `status` 中， 接下来会详细介绍每个字段的含义及其作用。
 
 - `status.name`
 
-    该字段用来保存 `chart package` 的名字。
-
+  该字段用来保存 `chart package` 的名字。
 - `status.versions`
 
-    该字段是数组，用来保存 `chart package` 的多个版本。每个版本包含的信息如下
+  该字段是数组，用来保存 `chart package` 的多个版本。每个版本包含的信息如下
 
-    - `status.versions[index].appVersion` 定义 `chart packge` 里面的应用的版本信息。
-    - `status.versions[index].createdAt` 创建时间
-    - `status.versions[index].updatedAt` 更新时间
-    - `status.versions[index].deprecated` 当前版本是否废弃
-    - `status.versions[index].version` `chart package` 的版本信息
-    - `status.versions[index].digest` 数字签名
+  - `status.versions[index].appVersion` 定义 `chart packge` 里面的应用的版本信息。
+  - `status.versions[index].createdAt` 创建时间
+  - `status.versions[index].updatedAt` 更新时间
+  - `status.versions[index].deprecated` 当前版本是否废弃
+  - `status.versions[index].version` `chart package` 的版本信息
+  - `status.versions[index].digest` 数字签名
+- `status.description`
 
-- `status.description` 
-
-    `chart package` 的描述信息
-
+  `chart package` 的描述信息
 - `status.maintainers`
 
-    该字段是数组类型，每一项都是 `chart package` 的维护者。每一项的包含的信息如下
+  该字段是数组类型，每一项都是 `chart package` 的维护者。每一项的包含的信息如下
 
-    - `status.maintainers[index].name` 维护者名字
-    - `status.maintainers[index].email` 维护者的邮箱
-    - `status.maintainers[index].url` 维护者的网站
-
-
+  - `status.maintainers[index].name` 维护者名字
+  - `status.maintainers[index].email` 维护者的邮箱
+  - `status.maintainers[index].url` 维护者的网站
 - `status.home`
 
-    组件的官网。
-
+  组件的官网。
 - `status.soureces`
 
-    该字段是字符串数组类型，定义组件代码仓库。
-
+  该字段是字符串数组类型，定义组件代码仓库。
 - `status.keywords`
 
-    该字段是字符串数组类型，定义与该组件关联的关键词。
-
+  该字段是字符串数组类型，定义与该组件关联的关键词。
 - `status.icon`
 
-    定义该组件的图标
-
+  定义该组件的图标
 - `status.deprecated`
 
-    定义当前组件是否废弃
+  定义当前组件是否废弃
 
 ## 工作原理
 
-组件也实现为 Kubernetes Operator，主要功能就是当组件创建，更新给每个组件添加label `kubebb.component.repository=<repository-name>`，方便搜索。
+组件也实现为 Kubernetes Operator，主要功能就是当组件创建，更新给每个组件添加 label `kubebb.component.repository=<repository-name>`，方便搜索。

--- a/docs/core/userguide/componentplan.md
+++ b/docs/core/userguide/componentplan.md
@@ -1,5 +1,137 @@
 ---
 sidebar_position: 3
 ---
+# 组件安装计划
 
-# 订阅
+组件安装计划类似于 Kubernetes 原生资源 Job，执行一次性任务，安装一个组件到集群，类似执行一次 `helm install`。
+
+## 使用
+
+下面是一个组件安装计划示例：
+
+```yaml
+apiVersion: core.kubebb.k8s.com.cn/v1alpha1
+kind: ComponentPlan
+metadata:
+  name: nginx-15.0.2
+  namespace: kubebb-system
+spec:
+  approved: true
+  component:
+    name: repository-bitnami-sample.nginx
+    namespace: kubebb-system
+  name: my-nginx
+  override:
+    images:
+      - name: docker.io/bitnami/nginx
+        newTag: latest # default image is docker.io/bitnami/nginx:1.25.1-debian-11-r0, will be replace by docker.io/bitnami/nginx:latest
+  repository:
+    name: repository-bitnami-sample
+    namespace: kubebb-system
+  version: 15.0.2
+#status:
+#  conditions:
+#    - lastTransitionTime: "2023-06-21T03:44:31Z"
+#      reason: ""
+#      status: "True"
+#      type: Approved
+#    - lastTransitionTime: "2023-06-21T03:44:37Z"
+#      reason: ""
+#      status: "True"
+#      type: Installed
+#    - lastTransitionTime: "2023-06-21T03:44:37Z"
+#      reason: ""
+#      status: "True"
+#      type: Succeeded
+#  images:
+#    - docker.io/bitnami/nginx:latest
+#  resources:
+#    - NewCreated: true
+#      apiVersion: v1
+#      kind: Service
+#      name: my-nginx
+#    - NewCreated: true
+#      apiVersion: apps/v1
+#      kind: Deployment
+#      name: my-nginx
+```
+
+上述组件安装计划定义了安装的组件是 `kubebb-system` 命名空间的 `repository-bitnami-sample.nginx`。
+安装名为 `my-nginx`，安装版本为 `15.0.2`。
+同时在安装时，将镜像 `docker.io/bitnami/nginx` 的 `tag` 替换为 `latest`。
+
+通过 `status` 字段可以看到，当前组件涉及的镜像以及资源。其中资源会标明是新创建还是更新现有资源，一个更新现有资源的例子为：
+
+```yaml
+  - apiVersion: v1
+    kind: Service
+    name: my-wordpress
+    specDiffwithExist: no spec diff, but some field like resourceVersion will update
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: my-wordpress
+    specDiffwithExist: |
+      metadata:
+        annotations: map[deployment.kubernetes.io/revision:2] -> <empty> (REMOVED)
+      spec:
+        replicas: 3 -> 1
+        template:
+          spec:
+            containers:
+              '[#0]':
+                image: docker.io/bitnami/wordpress:6.2.2-debian-11-r9 -> docker.io/bitnami/wordpress:6.2.2-debian-11-r11
+                resources:
+                  requests:
+                    cpu: 400m -> 300m
+                    memory: 1Gi -> 512Mi
+```
+
+## CRD 定义说明
+
+CRD 的代码定义位于 [componentplan_types.go](https://github.com/kubebb/core/blob/main/api/v1alpha1/componentplan_types.go)。接下来会详细介绍每个字段的含义及其作用。
+
+:::tip
+说明  对于下面的 yaml，我们想要访问 bar 字段，书写格式为 `spec.foo.bar`
+
+```yaml
+spec:
+  foo:
+    bar: xx
+```
+
+:::
+
+- `spec.componet`
+  该字段用来指明要监控的组件实例，一般使用 `namespace` 和 `name` 来唯一确定
+- `spec.repository`  *可选字段*
+  该字段用来指明要监控的组件所在的仓库实例，一般使用 `namespace` 和 `name` 来唯一确定，一般由控制器自动填充，不需要用户填写
+- `spec.version`
+  需要安装的组件版本。
+- `spec.approved`
+  是否同意安装。`bool` 类型，`true` 或 `false`，当为 `true` 时，自动触发安装流程。为 `false` 时，只会解析这个组件的 `manifest` 到 `ConfigMap` 中，不会安装。这时候，可以修改 `ConfigMap` 中的 `manifest`，实现进一步控制。
+- `spec.name`
+  组件安装到集群中的名称。类似 `helm release` 的名称
+- `spec.override` *可选字段*
+  用于覆盖原组件配置的字段。
+  - `spec.override.values`
+    `JSON` 格式的 `values`，用于覆盖默认值
+  - `spec.override.valuesFrom`
+    字段为数组。当要设定的字段偏多时，我们一般希望把 `values.yaml` 单独拿出来，放在 `ConfigMap` 或者 `Secret` 中，而且我们可能会有很多 `values.yaml` 文件。具体格式为：
+    - `spec.override.valuesFrom[].kind` `Secret` 或 `ConfigMap`
+    - `spec.override.valuesFrom[].name` `Secret` 或 `ConfigMap` 的名称，不需要 `namespace` 字段，因为只会查找和当前 ComponentPlan 同 `namespace` 的资源。
+    - `spec.override.valuesFrom[].valuesKey` `Secret` 或 `ConfigMap` 的 `data` 中的 `key`，默认为 `values.yaml` 会尝试先后查询 `ConfigMap` 中的 `Data` 和 `BinaryData` 字段，`Secret` 中的 `StringData` 和 `Data` 字段。
+  - `spec.override.set` 类似 `helm template --set` 的参数
+  - `spec.override.set-string` 类似 `helm template --set-string` 的参数
+  - `spec.override.set-file` 类似 `helm template --set-file` 的参数
+  - `spec.override.set-json` 类似 `helm template --set-json` 的参数
+  - `spec.override.set-literal` 类似 `helm template --set-literal` 的参数
+  - `spec.override.images`
+    数组。类似 `kustomize` 的镜像自定义参数
+    - `spec.override.images[].name` 去除 `tag` 后的原始镜像名称
+    - `spec.override.images[].newName` 替代原始镜像名称的名称
+    - `spec.override.images[].newTag` 替代原始 `tag` 的新 `tag` 名称
+    - `spec.override.images[].digest` 替代原始 `tag` 的新 `digest`，如果 `digest` 有值，会忽略 `newTag` 的值。
+
+## 工作原理
+
+组件安装计划以 Kubernetes Operator 方式实现。使用标准 `helm` 命令将 helm chart 包下载到本地后，首先通过 `helm template` 命令生成组件的 `manifest` 文件，然后执行 `Repository` 和 `ComponentPlan` 上的各种覆盖配置，比如镜像的覆盖配置，然后将结果放到同命名空间的名为 `manifest.<componentPlanName>` 的 `ConfigMap` 中，如果当前 `ComponentPlan` 的 `spec.approved` 字段为 `true`，那么会直接安装，如果为 `false`，会暂时停止在这里，直到这个字段为 `true`，这时，用户可以通过浏览 `ComponentPlan` 中的 `Status` 字段来查看安装这个组件会对集群中现有的资源造成什么影响，当前组件安装计划会新创建哪些资源，又会对哪些资源有修改。如果不满意，还可以直接修改 `manifest` 的 `ConfigMap`，满意后，然后再将 `spec.approved` 改为 `true`，进行安装。

--- a/docs/core/userguide/repository.md
+++ b/docs/core/userguide/repository.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 1
 ---
-
 # 仓库
 
 仓库是将 `chart repository` 映射为集群资源的一个概念。仓库定义了 `chart repository` 的 URL，认证信息等相关信息。仓库是组件部署，升级的基础。
@@ -30,75 +29,86 @@ spec:
       versions:
       - 16.1.14
       - 16.1.13
+  imageOverride:
+  - registry: docker.io
+    newRegistry: 192.168.1.1
+    pathOverride:
+      path: library
+      newPath: system-container
 ```
 
-上述仓库定义了数据来源是 `https://charts.bitnami.com/bitnami`，数据获取策略是，每隔120s获取一次，如果发生错误最多尝试5次。  
+上述仓库定义了数据来源是 `https://charts.bitnami.com/bitnami` ，数据获取策略是，每隔 120s 获取一次，如果发生错误最多尝试 5 次。
 对 `wordpress` 的版本定义了多虑条件，精确匹配 `16.1.14`, `16.1.13` 两个版本。
+对仓库中所有来自 `docker.io` 的镜像，替换为 `192.168.1.1` ，并将镜像路径为 `library` 的镜像替换为 `system-container` ，比如仓库中有镜像 `docker.io/library/nginx:v1.2.3` 会替换为 `192.168.1.1/system-container/nginx:v1.2.3` 。
 
 ## CRD 定义说明
 
-CRD 的代码定义位于 [RepositoryTypes](https://github.com/kubebb/core/blob/main/api/v1alpha1/repository_types.go)。接下来会详细介绍每个字段的含义及其作用。 
+CRD 的代码定义位于 [RepositoryTypes](https://github.com/kubebb/core/blob/main/api/v1alpha1/repository_types.go)。接下来会详细介绍每个字段的含义及其作用。
 
 :::tip
-说明  对于下面的 yaml，我们想要访问bar字段，书写格式为 `spec.foo.bar`
+说明  对于下面的 yaml，我们想要访问 bar 字段，书写格式为 `spec.foo.bar`
 
 ```yaml
 spec:
   foo:
     bar: xx
 ```
+
 :::
 
 - `spec.url`
 
-    该字段用来保存 `chart repository` 的地址
-
+  该字段用来保存 `chart repository` 的地址
 - `spec.authSecret`
 
-    对于需要认证，或者有自定义证书的 `chart repository`，需要将认证信息，证书信息存放到以该字段为名字的 `secret` 中。secret中的主要字段信息如下
+  对于需要认证，或者有自定义证书的 `chart repository`，需要将认证信息，证书信息存放到以该字段为名字的 `secret` 中。secret 中的主要字段信息如下
 
-    - `username` 定义认证需要的用户名
-    - `password` 定义认证需要的密码
-    - `cadata` 定义签发证书的RootCA
-    - `certdata` 定义客户端通过RootCA签发的证书
-    - `keydata` 定义客户端私钥
+  - `username` 定义认证需要的用户名
+  - `password` 定义认证需要的密码
+  - `cadata` 定义签发证书的 RootCA
+  - `certdata` 定义客户端通过 RootCA 签发的证书
+  - `keydata` 定义客户端私钥
 
-    如果服务端要求TLS双向认证，那么需要提供`certdata`和`keydata`。
+  如果服务端要求 TLS 双向认证，那么需要提供 `certdata` 和 `keydata`。
+- `spec.insecure`
 
-- `spec.insecure` 
-
-    是否跳过 https 验证
-
+  是否跳过 https 验证
 - `spec.repositoryType`
 
-    仓库类型，是字符串，理解为标记即可。
-
+  仓库类型，是字符串，理解为标记即可。
 - `spec.PullStrategy.intervalSeconds`
 
-    定义获取数据的周期，可以不填写，默认是120秒。
-
+  定义获取数据的周期，可以不填写，默认是 120 秒。
 - `spec.PullStrategy.timeoutSeconds`
 
-    定义一次http请求的超时时间。
-
+  定义一次 http 请求的超时时间。
 - `spec.PullStrategy.retry`
 
-    定义请求失败的重试次数。默认不填写，只会做一次请求
-
+  定义请求失败的重试次数。默认不填写，只会做一次请求
 - `spec.filter`
 
-    该字段是数组，定义了一系列的对 `chart package` 和 版本的过滤条件。因为是数组，所以可以出现对同一个 `chart package`的多个过滤条件，只会使用最后一条。
+  该字段是数组，定义了一系列的对 `chart package` 和 版本的过滤条件。因为是数组，所以可以出现对同一个 `chart package` 的多个过滤条件，只会使用最后一条。
 
-    数组的每一项的介绍
+  数组的每一项的介绍
 
-    - `spec.filter[index].name` 定义了要参与过滤的 `chart package` 的名称。
-    - `spec.filter[index].operation` 有两个可选值 `keep`, `ignore`。`ignore`表示忽略当前的`chart package`, `keep`表示会保留`chart package`并对当前的`chart pakcage`的版本进行过滤。
-    - `spec.filter[index].deprecated` `false`表示不保留`chart package`已经废弃的版本，`true`表示保留。
-    - `spec.filter[index].versionedFilterCond.versions` 是一个版本的数组，只要`chart package`的版本与该数组中任意一个精确匹配上，即符合规则。
-    - `spec.fitler[index].versionedFilterCond.versionRegexp` 版本过滤的正则表达式。
-    - `spec.filter[index].versionedFilterCond.versionConstraint` 版本验证条件，表达式格式请参考 [semver](https://github.com/Masterminds/semver#semver)
+  - `spec.filter[index].name` 定义了要参与过滤的 `chart package` 的名称。
+  - `spec.filter[index].operation` 有两个可选值 `keep`, `ignore`。`ignore` 表示忽略当前的 `chart package`, `keep` 表示会保留 `chart package` 并对当前的 `chart pakcage` 的版本进行过滤。
+  - `spec.filter[index].deprecated` `false` 表示不保留 `chart package` 已经废弃的版本，`true` 表示保留。
+  - `spec.filter[index].versionedFilterCond.versions` 是一个版本的数组，只要 `chart package` 的版本与该数组中任意一个精确匹配上，即符合规则。
+  - `spec.fitler[index].versionedFilterCond.versionRegexp` 版本过滤的正则表达式。
+  - `spec.filter[index].versionedFilterCond.versionConstraint` 版本验证条件，表达式格式请参考 [semver](https://github.com/Masterminds/semver#semver)
 
-    `versions, versionRegexp, VersionConstraint` 满足任一条件就会保留版本。
+  `versions, versionRegexp, VersionConstraint` 满足任一条件就会保留版本。
+- `spec.imageOverride`  非必需
+  该字段是数组，定义了一系列仓库级别的镜像覆盖策略。
+
+  每一项内容包括：
+
+  - `spec.imageOverride[].registry` 该镜像仓库域名地址，可以包含端口，例如：`docker.io`，`192.168.1.1:5000`
+  - `spec.imageOverride[].newRegistry` 要将 `registry` 替换后的镜像仓库域名地址，可以包含端口。
+  - `spec.imageOverride[].pathOverride` 非必需
+    - `spec.imageOverride[].pathOverride.path` 旧的镜像仓库路径，比如镜像地址 `docker.io/library/nginx:latest` 中的 path 为 `library`
+    - `spec.imageOverride[].pathOverride.newPath` 要将 `path` 替换后的镜像仓库新路径。
 
 ## 工作原理
 
@@ -108,10 +118,9 @@ spec:
 
 创建或者更新 `Repository` 时，会检查该资源是否添加 finalizers, 以及 URL 变更历史是否正确更新。
 
-当所有的更新都处理完成后，将会启动 `chartmuseum watcher`，在每次获取到若干的`chart package`后，与集群中已经存在的 `Component` 对比，将会执行`新增 component`, `更新 component`。
+当所有的更新都处理完成后，将会启动 `chartmuseum watcher`，在每次获取到若干的 `chart package` 后，与集群中已经存在的 `Component` 对比，将会执行 `新增 component`, `更新 component`。
 
-我们不会删除已经创建的 `Component`, 而是在发现集群中存在`Component`且并不存在于当前的`chart repository`中，那么会将其标记为废弃。
-
+我们不会删除已经创建的 `Component`, 而是在发现集群中存在 `Component` 且并不存在于当前的 `chart repository` 中，那么会将其标记为废弃。
 
 2. 当 `Repoistory` 删除时
 

--- a/docs/core/userguide/subscription.md
+++ b/docs/core/userguide/subscription.md
@@ -1,5 +1,92 @@
 ---
 sidebar_position: 3
 ---
-
 # 订阅
+
+创建一个订阅，表示用户将追踪一个组件（Component）在 仓库（Repository）中的更新，当组件更新时，该组件会根据订阅中的配置自动或待批准后安装到集群中。
+
+## 使用
+
+下面是一个订阅的示例：
+
+```yaml
+apiVersion: core.kubebb.k8s.com.cn/v1alpha1
+kind: Subscription
+metadata:
+  name: wordpress-sample
+  namespace: kubebb-system
+spec:
+  component:
+    name: repository-bitnami-sample.wordpress
+    namespace: kubebb-system
+  repository:
+    name: repository-bitnami-sample
+    namespace: kubebb-system
+  componentPlanInstallMethod: auto
+  name: my-wordpress
+#status:
+#  conditions:
+#    - lastTransitionTime: "2023-06-07T13:32:26Z"
+#      reason: ReconcileSuccess
+#      status: "True"
+#      type: SourceSynced
+#    - lastTransitionTime: "2023-06-07T13:34:35Z"
+#      reason: Available
+#      status: "True"
+#      type: Ready
+#    - lastTransitionTime: "2023-06-07T13:34:34Z"
+#      reason: ReconcileSuccess
+#      status: "True"
+#      type: PlanSynced
+#  installed:
+#    - componentPlan:
+#        name: sub-wordpress-sample-16.1.13
+#        namespace: kubebb-system
+#      installedTime: "2023-06-07T13:34:34Z"
+#      installedVersion:
+#        appVersion: 6.2.2
+#        createdAt: "2023-06-06T19:08:58Z"
+#        deprecated: false
+#        digest: 47096ed3f0a385e5830e90c75f443b7be107d7fa6df6aa869e7deb60b6cb6f8f
+#        updatedAt: "2023-06-07T13:34:31Z"
+#        version: 16.1.13
+#  repositoryHealth:
+#    healthy: true
+#    lastUpdated: "2023-06-07T13:34:35Z"
+#    repository:
+#      name: repository-bitnami-sample
+#      namespace: kubebb-system
+```
+
+上述订阅定义了监控的组件是 `kubebb-system` 命名空间的 `repository-bitnami-sample.wordpress`。
+当组件有新版本发布时，安装方式为 `auto` ，即自动安装。
+该组件会被安装为 `my-wordpress` 。
+查看该订阅的 `status` 可以看到该订阅会显示由该订阅创建的组件安装计划（ComponentPlan），以及该订阅对应的组件的仓库的健康状态。
+
+## CRD 定义说明
+
+CRD 的代码定义位于 [subscription_types.go](https://github.com/kubebb/core/blob/main/api/v1alpha1/subscription_types.go)。接下来会详细介绍每个字段的含义及其作用。
+
+:::tip
+说明  对于下面的 yaml，我们想要访问 bar 字段，书写格式为 `spec.foo.bar`
+
+```yaml
+spec:
+  foo:
+    bar: xx
+```
+
+:::
+
+- `spec.componet`
+  该字段用来指明要监控的组件实例，一般使用 `namespace` 和 `name` 来唯一确定
+- `spec.repository`  *可选字段*
+  该字段用来指明要监控的组件所在的仓库实例，一般使用 `namespace` 和 `name` 来唯一确定，一般由控制器自动填充，不需要用户填写。
+- `spec.componentPlanInstallMethod` *可选字段*
+  组件安装计划的安装方式，默认为 `auto`，可选项为 `auto` 或 `manual`
+- `spec.其他`
+  订阅中完整的包含了组件安装计划中的自定义配置字段。详细内容见组件安装计划的文档。
+
+## 工作原理
+
+订阅以 Kubernetes Operator 方式实现。当订阅控制器监视发现集群中订阅对应的组件创建或更新时，判断订阅未处理该更新事件时，用订阅中的组件安装计划配置创建一个名为 `sub-<订阅名>-<安装版本>` 的 `ComponentPlan`，触发后续的组件安装步骤。


### PR DESCRIPTION
Update componentplan_controller.go to check if the plan is approved before installing, and update example-test.sh with a correct Grafana image.

This change ensures that the component plan is not installed until it has been approved, providing better control and minimizing unnecessary installations. Also, the example script now uses the correct Grafana image for testing purposes.

Signed-off-by: Abirdcfly <fp544037857@gmail.com>