### PR TITLE
Fix: use latest version when quick-install

### DIFF
--- a/docs/quick-start/quick-install.md
+++ b/docs/quick-start/quick-install.md
@@ -176,7 +176,7 @@ metadata:
 spec:
   approved: true
   name: cluster-component
-  version: 0.1.4
+  version: ""
   override:
     set:
     - ingress-nginx.controller.nodeSelector.kubernetes\.io/hostname=kubebb-core-control-plane
@@ -235,7 +235,7 @@ metadata:
 spec:
   approved: true
   name: u4a-component
-  version: 0.1.10
+  version: ""
   wait: true
   override:
     valuesFrom:


### PR DESCRIPTION
The old chart version, specified in the quick-install doc, cannot be deployed. Change it to "" which means the latest version.